### PR TITLE
Loginkey updated to 32 characters

### DIFF
--- a/SQL/install.sql
+++ b/SQL/install.sql
@@ -69,7 +69,7 @@ CREATE TABLE IF NOT EXISTS `users` (
   `username` varchar(20) NOT NULL,
   `nickname` varchar(20) NOT NULL,
   `password` varchar(250) NOT NULL,
-  `loginKey` varchar(30) NOT NULL,
+  `loginKey` varchar(32) NOT NULL,
   `ipAddr` longtext NOT NULL,
   `age` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `active` tinyint(1) NOT NULL DEFAULT '1',


### PR DESCRIPTION
LoginKey was originally maximum 30 characters, but a MD5 hash is 32 characters.